### PR TITLE
Update SocketPlatform setup strategy

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -26,19 +26,25 @@ class Socket extends Emitter {
   static const int CLOSING = 2;
   static const int CLOSED = 3;
 
-  Socket._internal(this._socket, {this.authToken, this.strategy, this.listener}) {
+  Socket._internal(this._socket,
+      {this.authToken, this.strategy, this.listener}) {
     this._socket = _socket;
-    if (globalSocketPlatform == IoSocketPlatform) {
+    if (globalSocketPlatform is IoSocketPlatform) {
       _socket.listen(handleMessage).onDone(onSocketDone);
       onSocketOpened();
     } else {
-      _socket..onOpen.listen(onSocketOpened)..onClose.listen(onSocketDone)..onMessage.listen(handleMessage);
+      _socket
+        ..onOpen.listen(onSocketOpened)
+        ..onClose.listen(onSocketDone)
+        ..onMessage.listen(handleMessage);
     }
   }
 
   static Future<Socket> connect(String url,
-      {String authToken, ReconnectStrategy strategy, BasicListener listener}) async {
-    if (globalSocketPlatform == IoSocketPlatform){
+      {String authToken,
+      ReconnectStrategy strategy,
+      BasicListener listener}) async {
+    if (globalSocketPlatform is IoSocketPlatform) {
       var socket = await globalSocketPlatform.webSocket(url);
       return new Socket._internal(
         socket,
@@ -47,10 +53,11 @@ class Socket extends Emitter {
         listener: listener,
       );
     } else {
-        var _htmlsocket = globalSocketPlatform.webSocket(url);
-        var _socket = new Socket._internal(_htmlsocket, authToken: authToken, strategy: strategy, listener: listener);
-        await whenTrue(_socket._socket.onOpen);
-        return _socket;
+      var _htmlsocket = globalSocketPlatform.webSocket(url);
+      var _socket = new Socket._internal(_htmlsocket,
+          authToken: authToken, strategy: strategy, listener: listener);
+      await whenTrue(_socket._socket.onOpen);
+      return _socket;
     }
   }
 
@@ -64,8 +71,8 @@ class Socket extends Emitter {
     // stream exited without a true value, maybe return an exception.
   }
 
-  sendOrAdd([json]){
-    if (globalSocketPlatform == IoSocketPlatform) {
+  sendOrAdd([json]) {
+    if (globalSocketPlatform is IoSocketPlatform) {
       _socket.add(json);
     } else {
       _socket.send(json);
@@ -115,10 +122,10 @@ class Socket extends Emitter {
 
   void handleMessage([dynamic messageEvent]) {
     String message;
-    if (globalSocketPlatform != IoSocketPlatform) {
-      message = messageEvent.data;
-    } else {
+    if (globalSocketPlatform is IoSocketPlatform) {
       message = messageEvent;
+    } else {
+      message = messageEvent.data;
     }
     if (message == "#1") {
       sendOrAdd('#2');

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 
 import './parser.dart';
 import './socket_platform.dart';
-import './socket_platform_interface.dart' show IoSocketPlatformType;
 import './channel.dart';
 import './reconnect_strategy.dart';
 import './basic_listener.dart';
@@ -29,7 +28,7 @@ class Socket extends Emitter {
 
   Socket._internal(this._socket, {this.authToken, this.strategy, this.listener}) {
     this._socket = _socket;
-    if (globalSocketPlatform == IoSocketPlatformType) {
+    if (globalSocketPlatform == IoSocketPlatform) {
       _socket.listen(handleMessage).onDone(onSocketDone);
       onSocketOpened();
     } else {
@@ -39,7 +38,7 @@ class Socket extends Emitter {
 
   static Future<Socket> connect(String url,
       {String authToken, ReconnectStrategy strategy, BasicListener listener}) async {
-    if (globalSocketPlatform == IoSocketPlatformType){
+    if (globalSocketPlatform == IoSocketPlatform){
       var socket = await globalSocketPlatform.webSocket(url);
       return new Socket._internal(
         socket,
@@ -66,7 +65,7 @@ class Socket extends Emitter {
   }
 
   sendOrAdd([json]){
-    if (globalSocketPlatform == IoSocketPlatformType) {
+    if (globalSocketPlatform == IoSocketPlatform) {
       _socket.add(json);
     } else {
       _socket.send(json);
@@ -116,7 +115,7 @@ class Socket extends Emitter {
 
   void handleMessage([dynamic messageEvent]) {
     String message;
-    if (globalSocketPlatform != IoSocketPlatformType) {
+    if (globalSocketPlatform != IoSocketPlatform) {
       message = messageEvent.data;
     } else {
       message = messageEvent;

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 
 import './parser.dart';
-import './socket_platform_io.dart';
 import './socket_platform.dart';
+import './socket_platform_interface.dart' show IoSocketPlatformType;
 import './channel.dart';
 import './reconnect_strategy.dart';
 import './basic_listener.dart';
@@ -29,7 +29,7 @@ class Socket extends Emitter {
 
   Socket._internal(this._socket, {this.authToken, this.strategy, this.listener}) {
     this._socket = _socket;
-    if (globalSocketPlatform == IoSocketPlatform) {
+    if (globalSocketPlatform == IoSocketPlatformType) {
       _socket.listen(handleMessage).onDone(onSocketDone);
       onSocketOpened();
     } else {
@@ -39,7 +39,7 @@ class Socket extends Emitter {
 
   static Future<Socket> connect(String url,
       {String authToken, ReconnectStrategy strategy, BasicListener listener}) async {
-    if (globalSocketPlatform == IoSocketPlatform){
+    if (globalSocketPlatform == IoSocketPlatformType){
       var socket = await globalSocketPlatform.webSocket(url);
       return new Socket._internal(
         socket,
@@ -66,7 +66,7 @@ class Socket extends Emitter {
   }
 
   sendOrAdd([json]){
-    if (globalSocketPlatform == IoSocketPlatform) {
+    if (globalSocketPlatform == IoSocketPlatformType) {
       _socket.add(json);
     } else {
       _socket.send(json);
@@ -116,7 +116,7 @@ class Socket extends Emitter {
 
   void handleMessage([dynamic messageEvent]) {
     String message;
-    if (globalSocketPlatform != IoSocketPlatform) {
+    if (globalSocketPlatform != IoSocketPlatformType) {
       message = messageEvent.data;
     } else {
       message = messageEvent;

--- a/lib/src/socket_platform.dart
+++ b/lib/src/socket_platform.dart
@@ -1,15 +1,17 @@
-import 'socket_platform_interface.dart';
+export 'socket_platform_interface.dart';
 
-// Use conditional imports in order to automatically setup the platform without any user side setup.
-export 'socket_platform_interface.dart'
-  if (dart.library.io) './socket_platform_io.dart'
-  if (dart.library.js) './socket_platform_http.dart';
+import 'socket_platform_interface.dart'
+  if (dart.library.js) './socket_platform_http.dart'
+  if (dart.library.io) './socket_platform_io.dart';
 
-SocketPlatform _globalSocketPlatform;
+import 'socket_platform_interface.dart' show SocketPlatform;
+
+SocketPlatform _globalSocketPlatform = RuntimeSocketPlatform ;
 
 /// inherit this global one.
 SocketPlatform get globalSocketPlatform => _globalSocketPlatform;
 set globalSocketPlatform(SocketPlatform socketPlatform) {
+  print('setting socketPlatform too: $socketPlatform');
   if (socketPlatform == null) {
     throw new ArgumentError('socket: Global socket platform '
         'implementation must not be null.');

--- a/lib/src/socket_platform.dart
+++ b/lib/src/socket_platform.dart
@@ -11,7 +11,6 @@ SocketPlatform _globalSocketPlatform = RuntimeSocketPlatform ;
 /// inherit this global one.
 SocketPlatform get globalSocketPlatform => _globalSocketPlatform;
 set globalSocketPlatform(SocketPlatform socketPlatform) {
-  print('setting socketPlatform too: $socketPlatform');
   if (socketPlatform == null) {
     throw new ArgumentError('socket: Global socket platform '
         'implementation must not be null.');

--- a/lib/src/socket_platform.dart
+++ b/lib/src/socket_platform.dart
@@ -1,4 +1,14 @@
-import 'socket_platform_io.dart';
+import 'socket_platform_interface.dart';
+
+// Use conditional imports in order to automatically setup the platform without any user side setup.
+export 'socket_platform_interface.dart'
+  // `dart.library.js` is compatible with node and browser via dart2js -- `dart.library.html` will only work for the browser
+  // or at lest it seemed it should be, when I tried `dart.library.js` in chrome, it failed to evaluate to true
+  if (dart.library.io) './socket_platform_io.dart'
+  if (dart.library.js) './socket_platform_http.dart';
+
+SocketPlatform _globalSocketPlatform;
+
 /// inherit this global one.
 SocketPlatform get globalSocketPlatform => _globalSocketPlatform;
 set globalSocketPlatform(SocketPlatform socketPlatform) {
@@ -9,18 +19,8 @@ set globalSocketPlatform(SocketPlatform socketPlatform) {
   // Todo: log the socket platform implementation
   _globalSocketPlatform = socketPlatform;
 }
-SocketPlatform _globalSocketPlatform = IoSocketPlatform();
 
-/// Reset the globally configured socet platform.
+/// Reset the globally configured socket platform.
 void resetGlobalSocketPlatform() {
   _globalSocketPlatform = null;
-}
-
-
-
-abstract class SocketPlatform {
-  const SocketPlatform();
-
-  /// Constructs a new [WebSocket] instance.
-  dynamic webSocket([url]);
 }

--- a/lib/src/socket_platform.dart
+++ b/lib/src/socket_platform.dart
@@ -1,9 +1,9 @@
 import 'socket_platform_interface.dart';
 
+export 'socket_platform_interface.dart';
+
 // Use conditional imports in order to automatically setup the platform without any user side setup.
 export 'socket_platform_interface.dart'
-  // `dart.library.js` is compatible with node and browser via dart2js -- `dart.library.html` will only work for the browser
-  // or at lest it seemed it should be, when I tried `dart.library.js` in chrome, it failed to evaluate to true
   if (dart.library.io) './socket_platform_io.dart'
   if (dart.library.js) './socket_platform_http.dart';
 

--- a/lib/src/socket_platform.dart
+++ b/lib/src/socket_platform.dart
@@ -1,7 +1,5 @@
 import 'socket_platform_interface.dart';
 
-export 'socket_platform_interface.dart';
-
 // Use conditional imports in order to automatically setup the platform without any user side setup.
 export 'socket_platform_interface.dart'
   if (dart.library.io) './socket_platform_io.dart'

--- a/lib/src/socket_platform.dart
+++ b/lib/src/socket_platform.dart
@@ -6,7 +6,7 @@ import 'socket_platform_interface.dart'
 
 import 'socket_platform_interface.dart' show SocketPlatform;
 
-SocketPlatform _globalSocketPlatform = RuntimeSocketPlatform ;
+SocketPlatform _globalSocketPlatform = RuntimeSocketPlatform;
 
 /// inherit this global one.
 SocketPlatform get globalSocketPlatform => _globalSocketPlatform;

--- a/lib/src/socket_platform_http.dart
+++ b/lib/src/socket_platform_http.dart
@@ -1,11 +1,14 @@
 import 'dart:html';
 
+import 'socket_platform_interface.dart' show HttpSocketPlatformType, SocketPlatform;
 import 'socket_platform.dart';
 
 const HttpSocketPlatform httpSocketPlatform = const HttpSocketPlatform();
-class HttpSocketPlatform extends SocketPlatform {
+class HttpSocketPlatform extends HttpSocketPlatformType {
   const HttpSocketPlatform();
 
   @override
   dynamic webSocket([url]) => new WebSocket(url);
 }
+
+SocketPlatform globalSocketPlatform = httpSocketPlatform;

--- a/lib/src/socket_platform_http.dart
+++ b/lib/src/socket_platform_http.dart
@@ -1,14 +1,13 @@
 import 'dart:html';
 
-import 'socket_platform_interface.dart' show HttpSocketPlatformType, SocketPlatform;
-import 'socket_platform.dart';
+import 'socket_platform_interface.dart' as socketinterface;
 
 const HttpSocketPlatform httpSocketPlatform = const HttpSocketPlatform();
-class HttpSocketPlatform extends HttpSocketPlatformType {
+class HttpSocketPlatform extends socketinterface.HttpSocketPlatform {
   const HttpSocketPlatform();
 
   @override
   dynamic webSocket([url]) => new WebSocket(url);
 }
 
-SocketPlatform globalSocketPlatform = httpSocketPlatform;
+const socketinterface.SocketPlatform RuntimeSocketPlatform = httpSocketPlatform;

--- a/lib/src/socket_platform_interface.dart
+++ b/lib/src/socket_platform_interface.dart
@@ -1,17 +1,20 @@
-abstract class SocketPlatform {
+class SocketPlatform {
   const SocketPlatform();
   /// Constructs a new [WebSocket] instance.
-  dynamic webSocket([url]);
+  dynamic webSocket([url]) {}
 }
 
 // Declare all the Base Types of SocketPlatforms here so that they can be used
 // for type checking externally without breaking platform specific imports
 // such as `dart:io` or `dart:html` when not on that platform.
 
-abstract class HttpSocketPlatformType extends SocketPlatform {
-  const HttpSocketPlatformType();
+/// Stub for dynamic Import
+class HttpSocketPlatform extends SocketPlatform {
+  const HttpSocketPlatform();
 }
 
-abstract class IoSocketPlatformType extends SocketPlatform {
-  const IoSocketPlatformType();
+class IoSocketPlatform extends SocketPlatform {
+  const IoSocketPlatform();
 }
+
+const SocketPlatform RuntimeSocketPlatform = null;

--- a/lib/src/socket_platform_interface.dart
+++ b/lib/src/socket_platform_interface.dart
@@ -1,0 +1,17 @@
+abstract class SocketPlatform {
+  const SocketPlatform();
+  /// Constructs a new [WebSocket] instance.
+  dynamic webSocket([url]);
+}
+
+// Declare all the Base Types of SocketPlatforms here so that they can be used
+// for type checking externally without breaking platform specific imports
+// such as `dart:io` or `dart:html` when not on that platform.
+
+abstract class HttpSocketPlatformType extends SocketPlatform {
+  const HttpSocketPlatformType();
+}
+
+abstract class IoSocketPlatformType extends SocketPlatform {
+  const IoSocketPlatformType();
+}

--- a/lib/src/socket_platform_io.dart
+++ b/lib/src/socket_platform_io.dart
@@ -3,10 +3,11 @@ import 'dart:io';
 import 'socket_platform_interface.dart' as socketinterface;
 
 const IoSocketPlatform ioSocketPlatform = const IoSocketPlatform();
+
 class IoSocketPlatform extends socketinterface.IoSocketPlatform {
   const IoSocketPlatform();
 
-  Function webSocket([url]) => WebSocket.connect;
+  Future<WebSocket> webSocket([url]) => WebSocket.connect(url);
 }
 
 const socketinterface.SocketPlatform RuntimeSocketPlatform = ioSocketPlatform;

--- a/lib/src/socket_platform_io.dart
+++ b/lib/src/socket_platform_io.dart
@@ -1,9 +1,13 @@
 import 'dart:io';
+
+import 'socket_platform_interface.dart' show IoSocketPlatformType, SocketPlatform;
 import 'socket_platform.dart';
 
 const IoSocketPlatform ioSocketPlatform = const IoSocketPlatform();
-class IoSocketPlatform extends SocketPlatform {
+class IoSocketPlatform extends IoSocketPlatformType {
   const IoSocketPlatform();
 
   Function webSocket([url]) => WebSocket.connect;
 }
+
+SocketPlatform globalSocketPlatform = ioSocketPlatform;

--- a/lib/src/socket_platform_io.dart
+++ b/lib/src/socket_platform_io.dart
@@ -1,13 +1,12 @@
 import 'dart:io';
 
-import 'socket_platform_interface.dart' show IoSocketPlatformType, SocketPlatform;
-import 'socket_platform.dart';
+import 'socket_platform_interface.dart' as socketinterface;
 
 const IoSocketPlatform ioSocketPlatform = const IoSocketPlatform();
-class IoSocketPlatform extends IoSocketPlatformType {
+class IoSocketPlatform extends socketinterface.IoSocketPlatform {
   const IoSocketPlatform();
 
   Function webSocket([url]) => WebSocket.connect;
 }
 
-SocketPlatform globalSocketPlatform = ioSocketPlatform;
+const socketinterface.SocketPlatform RuntimeSocketPlatform = ioSocketPlatform;


### PR DESCRIPTION
# Issue
An issue was discovered today that prevents socketcluster_client from being used with js/web based projects due to dart 2 now rejecting `import 'dart:io';` being in a web project at all even when only being imported transitively and no code for it was executed, which was previously done in order to use the `IoSocketPlatform` type in `socket.dart`.

# Fix
- Isolate the `dart:io` and `dart:html` import containing files behind conditional imports.
- Add `SocketPlatform` and other Base Types into separate `interface` class so they can be used for type checking.
- Add initial assignment to `_globalSocketPlatform` through a conditional import `RuntimeSocketPlatform` constant in the respective file, this makes the platform be auto configured! 
  - Web users will no longer need to add `globalSocketPlatform = httpSocketPlatform;` as the conditional import does this for them.

# QA
- [ ] Flutter based projects continue to work as expected. (@pauldemarco any chance you could test this?)
- [x] Web projects no longer have build time issues due to import. (confirmed by @kealjones-wk  with an over_react project)