### PR TITLE
Support null safety

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 
 class MyListener extends BasicListener {
   @override
-  void onAuthentication(Socket socket, bool status) {
+  void onAuthentication(Socket socket, bool? status) {
     print('onAuthentication: socket $socket status $status');
   }
 
@@ -28,7 +28,7 @@ class MyListener extends BasicListener {
   }
 
   @override
-  void onSetAuthToken(String token, Socket socket) {
+  void onSetAuthToken(String? token, Socket socket) {
     print('onSetAuthToken: socket $socket token $token');
     socket.authToken = token;
   }

--- a/lib/socketcluster_client.dart
+++ b/lib/socketcluster_client.dart
@@ -1,3 +1,1 @@
-library socketcluster_client;
-
 export 'package:socketcluster_client/src/socketcluster_client.dart';

--- a/lib/src/basic_listener.dart
+++ b/lib/src/basic_listener.dart
@@ -14,7 +14,7 @@ abstract class BasicListener {
   ///
   void onConnectError(Socket socket, dynamic e);
 
-  void onAuthentication(Socket socket, bool status);
+  void onAuthentication(Socket socket, bool? status);
 
-  void onSetAuthToken(String token, Socket socket);
+  void onSetAuthToken(String? token, Socket socket);
 }

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -8,7 +8,7 @@ class Channel
 
   Channel(this.socket, this.name);
 
-  Channel subscribe([AckCall ack])
+  Channel subscribe([AckCall? ack])
   {
     socket.subscribe(name, ack);
     return this;
@@ -19,12 +19,12 @@ class Channel
     socket.onSubscribe(name, listener);
   }
 
-  void publish(dynamic data, [AckCall ack])
+  void publish(dynamic data, [AckCall? ack])
   {
     socket.publish(name, data, ack);
   }
 
-  void unsubscribe([AckCall ack])
+  void unsubscribe([AckCall? ack])
   {
     socket.unsubscribe(name, ack);
     socket.channels.remove(this);

--- a/lib/src/emitter.dart
+++ b/lib/src/emitter.dart
@@ -1,8 +1,8 @@
 
 
-typedef Listener(String name, dynamic data);
+typedef Listener(String? name, dynamic data);
 
-typedef AckListener(String name, dynamic data, AckCall ack);
+typedef AckListener(String? name, dynamic data, AckCall ack);
 
 typedef AckCall(String name, dynamic error, dynamic data);
 
@@ -44,29 +44,29 @@ class Emitter {
     return this;
   }
 
-  Emitter handleEmit(String event, dynamic object) {
+  Emitter handleEmit(String? event, dynamic object) {
     if (_singleCallbacks.containsKey(event)) {
-      var listener = _singleCallbacks[event];
+      var listener = _singleCallbacks[event!]!;
       listener(event, object);
     }
     return this;
   }
 
-  Emitter handleEmitAck(String event, dynamic object, AckCall ack) {
+  Emitter handleEmitAck(String? event, dynamic object, AckCall ack) {
     if (_singleAckCallbacks.containsKey(event)) {
-      var listener = _singleAckCallbacks[event];
+      var listener = _singleAckCallbacks[event!]!;
       listener(event, object, ack);
     }
     return this;
   }
 
-  Emitter handlePublish(String event, dynamic object) {
+  Emitter handlePublish(String? event, dynamic object) {
     if (_publishCallbacks.containsKey(event)) {
-      var listener = _publishCallbacks[event];
+      var listener = _publishCallbacks[event!]!;
       listener(event, object);
     }
     return this;
   }
 
-  bool hasEventAck(String event) => _singleAckCallbacks.containsKey(event);
+  bool hasEventAck(String? event) => _singleAckCallbacks.containsKey(event);
 }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -8,7 +8,7 @@ enum ParseResult {
 }
 
 class Parser {
-  static ParseResult parse(dynamic dataObject, int rid, int cid, String event) {
+  static ParseResult parse(dynamic dataObject, int? rid, int? cid, String? event) {
     if (event == null)
       return rid == 1 ? ParseResult.ISAUTHENTICATED : ParseResult.ACKRECEIVE;
     switch (event) {

--- a/lib/src/reconnect_strategy.dart
+++ b/lib/src/reconnect_strategy.dart
@@ -16,7 +16,7 @@ class ReconnectStrategy
    * The maximum number of reconnection attempts that will be made before giving up. If null, reconnection attempts will be continue to be made forever.
    * Default: null
    */
-  final int maxAttempts;
+  final int? maxAttempts;
 
   var attmptsMade = 0;
 
@@ -36,5 +36,5 @@ class ReconnectStrategy
     return reconnectInterval;
   }
 
-  bool areAttemptsComplete() => attmptsMade >= maxAttempts;
+  bool areAttemptsComplete() => attmptsMade >= maxAttempts!;
 }

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -10,14 +10,14 @@ import './emitter.dart';
 
 class Socket extends Emitter {
   dynamic _socket;
-  String url;
-  String id;
-  final ReconnectStrategy strategy;
-  final BasicListener listener;
+  String? url;
+  String? id;
+  final ReconnectStrategy? strategy;
+  final BasicListener? listener;
   int _counter = 0;
-  String authToken;
-  final List<Channel> channels = new List();
-  final Map<int, List<dynamic>> _acks = new Map();
+  String? authToken;
+  final List<Channel> channels = [];
+  final Map<int, List<dynamic>> _acks = {};
 
   int get state => _socket.readyState ?? CLOSED;
 
@@ -41,9 +41,9 @@ class Socket extends Emitter {
   }
 
   static Future<Socket> connect(String url,
-      {String authToken,
-      ReconnectStrategy strategy,
-      BasicListener listener}) async {
+      {String? authToken,
+      ReconnectStrategy? strategy,
+      BasicListener? listener}) async {
     if (globalSocketPlatform is IoSocketPlatform) {
       var socket = await globalSocketPlatform.webSocket(url);
       return new Socket._internal(
@@ -104,13 +104,13 @@ class Socket extends Emitter {
     dynamic json = jsonEncode(authObject);
     sendOrAdd(json);
     if (listener != null) {
-      listener.onConnected(this);
+      listener!.onConnected(this);
     }
   }
 
   void onSocketDone([event]) {
     if (listener != null) {
-      listener.onDisconnected(this);
+      listener!.onDisconnected(this);
     }
   }
 
@@ -121,7 +121,7 @@ class Socket extends Emitter {
   }
 
   void handleMessage([dynamic messageEvent]) {
-    String message;
+    String? message;
     if (globalSocketPlatform is IoSocketPlatform) {
       message = messageEvent;
     } else {
@@ -132,26 +132,26 @@ class Socket extends Emitter {
     } else {
 //      print('Message received: $message');
 
-      var map = jsonDecode(message);
+      var map = jsonDecode(message!);
       var data = map['data'];
-      int rid = map['rid'];
-      int cid = map['cid'];
-      String event = map['event'];
+      int? rid = map['rid'];
+      int? cid = map['cid'];
+      String? event = map['event'];
 
 //      print('Event: $event, rid: $rid, cid: $cid, data: $data');
 
       switch (Parser.parse(data, rid, cid, event)) {
         case ParseResult.ISAUTHENTICATED:
 //          print('IS authenticated got called');
-          id = data['id'] as String;
-          bool auth = data['isAuthenticated'] as bool;
+          id = data['id'] as String?;
+          bool? auth = data['isAuthenticated'] as bool?;
           if (listener != null) {
-            listener.onAuthentication(this, auth);
+            listener!.onAuthentication(this, auth);
           }
           subscribeChannels();
           break;
         case ParseResult.PUBLISH:
-          handlePublish(data['channel'] as String, data['data']);
+          handlePublish(data['channel'] as String?, data['data']);
 //          print('Publish got called');
           break;
         case ParseResult.REMOVETOKEN:
@@ -160,7 +160,7 @@ class Socket extends Emitter {
           break;
         case ParseResult.SETTOKEN:
           if (listener != null) {
-            listener.onSetAuthToken(data['token'] as String, this);
+            listener!.onSetAuthToken(data['token'] as String?, this);
           }
 //          print('Set token got called');
           break;
@@ -174,7 +174,7 @@ class Socket extends Emitter {
         case ParseResult.ACKRECEIVE:
 //          print('Ack receive got called');
           if (_acks.containsKey(rid)) {
-            var mapObj = _acks[rid];
+            var mapObj = _acks[rid!];
             _acks.remove(rid);
             if (mapObj != null) {
               AckCall fn = mapObj[1];
@@ -192,19 +192,19 @@ class Socket extends Emitter {
     }
   }
 
-  AckCall ack(int cid) {
+  AckCall ack(int? cid) {
     return (name, dynamic error, dynamic data) {
       var message = {
-        'error': error as String,
-        'data': data as String,
-        'rid': cid as String, // FIXME: rid -> cid?
+        'error': error as String?,
+        'data': data as String?,
+        'rid': cid as String?, // FIXME: rid -> cid?
       };
       var json = jsonEncode(message);
       sendOrAdd(json);
     };
   }
 
-  Socket emit(String event, Object data, [AckCall ack]) {
+  Socket emit(String event, Object data, [AckCall? ack]) {
     int count = ++_counter;
     var message = new Map<String, Object>();
     message['event'] = event;
@@ -219,7 +219,7 @@ class Socket extends Emitter {
     return this;
   }
 
-  Socket subscribe(String channel, [AckCall ack]) {
+  Socket subscribe(String channel, [AckCall? ack]) {
     int count = ++_counter;
     var message = {
       'event': '#subscribe',
@@ -232,7 +232,7 @@ class Socket extends Emitter {
     return this;
   }
 
-  Socket unsubscribe(String channel, [AckCall ack]) {
+  Socket unsubscribe(String channel, [AckCall? ack]) {
     int count = ++_counter;
     var message = {'event': '#unsubscribe', 'data': channel, 'cid': count};
     if (ack != null) _acks[count] = getAckObject(channel, ack);
@@ -241,7 +241,7 @@ class Socket extends Emitter {
     return this;
   }
 
-  Socket publish(String channel, Object data, [AckCall ack]) {
+  Socket publish(String channel, Object data, [AckCall? ack]) {
     int count = ++_counter;
     var message = {
       'event': '#publish',

--- a/lib/src/socket_platform.dart
+++ b/lib/src/socket_platform.dart
@@ -1,20 +1,16 @@
 export 'socket_platform_interface.dart';
 
 import 'socket_platform_interface.dart'
-  if (dart.library.js) './socket_platform_http.dart'
-  if (dart.library.io) './socket_platform_io.dart';
+    if (dart.library.js) './socket_platform_http.dart'
+    if (dart.library.io) './socket_platform_io.dart';
 
 import 'socket_platform_interface.dart' show SocketPlatform;
 
-SocketPlatform _globalSocketPlatform = RuntimeSocketPlatform;
+SocketPlatform? _globalSocketPlatform = RuntimeSocketPlatform;
 
 /// inherit this global one.
-SocketPlatform get globalSocketPlatform => _globalSocketPlatform;
+SocketPlatform get globalSocketPlatform => _globalSocketPlatform!;
 set globalSocketPlatform(SocketPlatform socketPlatform) {
-  if (socketPlatform == null) {
-    throw new ArgumentError('socket: Global socket platform '
-        'implementation must not be null.');
-  }
   // Todo: log the socket platform implementation
   _globalSocketPlatform = socketPlatform;
 }

--- a/lib/src/socket_platform_interface.dart
+++ b/lib/src/socket_platform_interface.dart
@@ -17,4 +17,4 @@ class IoSocketPlatform extends SocketPlatform {
   const IoSocketPlatform();
 }
 
-const SocketPlatform RuntimeSocketPlatform = null;
+const SocketPlatform? RuntimeSocketPlatform = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ authors:
   - Michael Marner <michael@20papercups.net>
 homepage: https://github.com/pauldemarco/socketcluster_client
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
-  test: ^1.3.0
+  test: ^1.16.8


### PR DESCRIPTION
Migrate to null safety

* Follows the documentation for migrating: https://dart.dev/null-safety/migration-guide
* A few manual modifications (list constructors) that are no longer allowed in null-safe code

This mostly maintains existing behaviour, in that most things remain nullable and have checks for null.

Future work could be to put null safety to use and clean up some of the code.

Closes #13 